### PR TITLE
Typo fix in the TestPlan's _attributes [BZ#1304295]

### DIFF
--- a/source/mutable.py
+++ b/source/mutable.py
@@ -82,7 +82,7 @@ class TestPlan(Mutable):
     _identifier_width = 5
 
     # List of all object attributes (used for init & expiration)
-    _attributes = ["author", "caseplans" "children", "components", "name",
+    _attributes = ["author", "caseplans", "children", "components", "name",
             "owner", "parent", "product", "status", "tags", "testcases",
             "testruns", "type", "version"]
 


### PR DESCRIPTION
Small typo fix, but it enables to use caseplans and children attributes in the TestCase class.