### PR TITLE
Port to python-gssapi from pykerberos

### DIFF
--- a/python-nitrate.spec
+++ b/python-nitrate.spec
@@ -1,6 +1,6 @@
 Name: python-nitrate
 Version: 1.3
-Release: 2%{?dist}
+Release: 3%{?dist}
 
 Summary: Python API for the Nitrate test case management system
 Group: Development/Languages
@@ -11,7 +11,7 @@ Source0: http://psss.fedorapeople.org/python-nitrate/%{name}-%{version}.tar.bz2
 
 BuildArch: noarch
 BuildRequires: python-devel
-Requires: python-kerberos python-psycopg2
+Requires: python-gssapi python-psycopg2
 
 %description
 python-nitrate is a Python interface to the Nitrate test case
@@ -40,6 +40,9 @@ install -pm 644 docs/*.1.gz %{buildroot}%{_mandir}/man1
 %doc COPYING README examples
 
 %changelog
+* Mon Feb 19 2018 Robbie Harwood <rharwood@redhat.com> 1.3-3
+- Port to python-gssapi
+
 * Tue May 10 2016 Martin Frodl <mfrodl@redhat.com> 1.3-2
 - Removed obsolete project page links
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='nitrate',
       author_email='psplicha@redhat.com',
       license='LGPLv2+',
       install_requires=[
-          'pykerberos',
+          'gssapi',
           'psycopg2',
           ],
       url='https://psss.fedorapeople.org/python-nitrate/',


### PR DESCRIPTION
Some notes:

- I'm not sure if there's a test suite here.  If you have one, I'm happy to run against it.
- I haven't migrated all references from mod_auth_kerb to mod_auth_gssapi because it looks like this will affect config options.  I'm happy to do that, if desired.
- There are libraries ([requests-gssapi](https://github.com/pythongssapi/requests-gssapi/), [urllib-gssapi](https://github.com/pythongssapi/urllib-gssapi)) that will speak this protocol for you.  I'm happy to provide a patch for either of those if you would prefer.

Thanks!