### PR TITLE
TestPlan.sortkey too slow

### DIFF
--- a/source/mutable.py
+++ b/source/mutable.py
@@ -366,6 +366,15 @@ class TestPlan(Mutable):
 
     def sortkey(self, testcase, sortkey=None):
         """ Get or set sortkey for given test case """
+        # Try already seen values 
+        try:
+            value = self._sortkey_lookup[testcase.id]
+            if sortkey is None: # no need to change value
+                return value
+        except AttributeError: # cache doesn't exist yet
+            self._sortkey_lookup = {}
+        except KeyError: # not yet in cache
+            pass
         # Make sure the test case we got belongs to the test plan
         if testcase not in self.testcases:
             raise NitrateError("Test case {0} not in test plan {1}".format(
@@ -380,6 +389,8 @@ class TestPlan(Mutable):
         # Modify the sortkey if requested
         if sortkey is not None:
             caseplan.sortkey = sortkey
+        # Cache sortkey for future
+        self._sortkey_lookup[testcase.id] = sortkey
         # And finally return the current value
         return caseplan.sortkey
 


### PR DESCRIPTION
Add caching functionality, speeds stuff a bit.
Use try/except to create structure and cache data.