### PR TITLE
Enable copr builds and add packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,14 @@
+downstream_package_name: python-nitrate
+jobs:
+- job: copr_build
+  metadata:
+    targets:
+    - fedora-30-x86_64
+    - fedora-31-x86_64
+    - fedora-rawhide-x86_64
+  trigger: pull_request
+specfile_path: python-nitrate.spec
+synced_files:
+- python-nitrate.spec
+- .packit.yaml
+upstream_package_name: python-nitrate

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,14 +1,20 @@
+upstream_package_name: python-nitrate
 downstream_package_name: python-nitrate
+
+specfile_path: python-nitrate.spec
+synced_files: [python-nitrate.spec]
+
+actions:
+  create-archive:
+  - make tarball
+  get-current-version:
+  - make version
+
 jobs:
 - job: copr_build
   metadata:
     targets:
-    - fedora-30-x86_64
-    - fedora-31-x86_64
-    - fedora-rawhide-x86_64
+    - fedora-all
+    - epel-8
+    - epel-7
   trigger: pull_request
-specfile_path: python-nitrate.spec
-synced_files:
-- python-nitrate.spec
-- .packit.yaml
-upstream_package_name: python-nitrate

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ build:
 
 tarball: build
 	cd $(TMP) && tar cfj SOURCES/$(PACKAGE).tar.bz2 $(PACKAGE)
+	@echo ./tmp/SOURCES/$(PACKAGE).tar.bz2
+
+version:
+	@echo "$(VERSION)"
 
 rpm: tarball
 	rpmbuild --define '_topdir $(TMP)' -bb python-nitrate.spec


### PR DESCRIPTION

Let us introduce [packit service](https://packit.dev) to you - the automation to integrate upstream open source projects into Fedora operating system.

After merging this PR, you are just a few steps away from RPM builds being automatically triggered on your PR's.
It means, that you'll be able to try and play with your change, packaged as an RPM.

But there is more. By using packit, you can for example enable adding new releases into Fedora Rawhide.

What are the next steps?
* Install [Packit-as-a-Service github application](https://github.com/marketplace/packit-as-a-service) in your repo
* In case you are first user, wait for account approval
* Enjoy the built RPMs!

For more info, please:
 * check out the documentation: https://packit.dev/docs/
 * contact @packit-service
