### PR TITLE
Output nicer tracebacks on connection failures

### DIFF
--- a/source/xmlrpc_driver.py
+++ b/source/xmlrpc_driver.py
@@ -134,7 +134,10 @@ class CookieTransport(xmlrpclib.Transport):
         except xmlrpclib.Fault:
             raise
         finally:
-            h.close()
+            try:
+                h.close()
+            except NameError:  # h not initialized yet
+                pass
 
     # Override the appropriate request method
     single_request = single_request_with_cookies # python 2.7+


### PR DESCRIPTION
In xmlrpc_driver.CookieTransport.single_request_with_cookies,
the finalizer accesses a potentially uninitialized variable,
bloating the traceback with irrelevant info.

Is meant to partially alleviate https://github.com/psss/tmt/issues/57