### PR TITLE
Enable building of `epel9` packages as well

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,6 +15,7 @@ jobs:
   metadata:
     targets:
     - fedora-all
+    - epel-9
     - epel-8
     - epel-7
   trigger: pull_request
@@ -22,9 +23,10 @@ jobs:
 - job: copr_build
   trigger: commit
   metadata:
-    branch: master
+    branch: main
     targets:
     - fedora-all
+    - epel-9
     - epel-8
     - epel-7
     list_on_homepage: True


### PR DESCRIPTION
It's time to build `epel9` as well.