### PR TITLE
Properly handle string bug identifiers

### DIFF
--- a/tests/config.fmf
+++ b/tests/config.fmf
@@ -3,4 +3,10 @@ test: |
     set +o pipefail
     command="import nitrate; print(nitrate.TestCase(1234))"
     message="Please, provide at least a minimal config"
-    python -c "$command" 2>&1 | grep "$message"
+    $python -c "$command" 2>&1 | grep "$message"
+environment:
+    python: python3
+adjust+:
+  - environment:
+        python: python2
+    when: distro == centos-7

--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -1,5 +1,5 @@
 require: python3-nitrate
 
 adjust:
-    require: python2-nitrate
+  - require: python2-nitrate
     when: distro == centos-7


### PR DESCRIPTION
Fixes problem when `Bug()` initialized directly using id and system.