### PR TITLE
Release python-nitrate-1.8.2

### DIFF
--- a/python-nitrate.spec
+++ b/python-nitrate.spec
@@ -1,5 +1,5 @@
 Name: python-nitrate
-Version: 1.8
+Version: 1.8.2
 Release: 1%{?dist}
 
 Summary: Python API for the Nitrate test case management system
@@ -126,6 +126,11 @@ pathfix.py -pni "%{__python3} %{py3_shbang_opts}i" %{buildroot}%{_bindir}/nitrat
 %license LICENSE
 
 %changelog
+* Thu Jun 09 2022 Petr Šplíchal <psplicha@redhat.com> - 1.8.2-1
+- Do not use the spec release for the pip version
+- Properly handle string bug identifiers
+- Enable basic sanity and integration tests
+
 * Wed Jun 08 2022 Petr Šplíchal <psplicha@redhat.com> - 1.8-1
 - Nitrate Bug id can be string (for e.g. Jira)
 

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,13 @@ description = 'Python API for the Nitrate test case management system'
 with open("README") as readme:
     long_description = readme.read()
 
-# Parse version and release from master spec file
+# Parse version from the spec file
 with open("python-nitrate.spec") as specfile:
     lines = "\n".join(line.rstrip() for line in specfile)
     version = re.search('Version: (.+)', lines).group(1).rstrip()
-    release = re.search('Release: (\d+)', lines).group(1).rstrip()
 
 setup(name='nitrate',
-      version='{0}'.format('.'.join([version, release])),
+      version=version,
       packages=['nitrate'],
       package_dir={'nitrate': 'source'},
       scripts=['source/nitrate'],


### PR DESCRIPTION
- Do not use the spec release for the pip version
- Properly handle string bug identifiers
- Enable basic sanity and integration tests