### PR TITLE
Use the `py3_shebang_fix` macro instead of `pathfix.py`

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -21,7 +21,6 @@ jobs:
   - fedora-all
   - epel-9
   - epel-8
-  - epel-7
 
 - job: tests
   trigger: pull_request
@@ -29,7 +28,6 @@ jobs:
   - fedora-all
   - epel-9
   - epel-8
-  - epel-7
 
 - job: copr_build
   trigger: commit
@@ -38,7 +36,6 @@ jobs:
   - fedora-all
   - epel-9
   - epel-8
-  - epel-7
   list_on_homepage: True
   preserve_project: True
   owner: psss

--- a/python-nitrate.spec
+++ b/python-nitrate.spec
@@ -107,8 +107,9 @@ export LANG=en_US.utf-8
 %py3_install
 mkdir -p %{buildroot}%{_mandir}/man1
 install -pm 644 docs/*.1.gz %{buildroot}%{_mandir}/man1
-# Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1335203
-pathfix.py -pni "%{__python3} %{py3_shbang_opts}i" %{buildroot}%{_bindir}/nitrate
+
+# https://fedoraproject.org/wiki/Changes/Python3.12#pathfix.py_tool_will_be_removed
+%py3_shebang_fix %{buildroot}%{_bindir}/nitrate
 
 %if %{with python2}
 %files -n python2-nitrate


### PR DESCRIPTION
Fix building on `fedora-39`. Also disable building on `epel-7` (too old).
See also: https://fedoraproject.org/wiki/Changes/Python3.12#pathfix.py_tool_will_be_removed