### PR TITLE
Fix initializing version object by a version object

### DIFF
--- a/source/mutable.py
+++ b/source/mutable.py
@@ -565,7 +565,7 @@ class TestRun(Mutable):
         elif isinstance(version, int):
             version = Version(version)
         else:
-            version = Version(name=version, product=product)
+            version = Version(name=str(version), product=product)
         hash["product_version"] = version.id
 
         # Build & errata


### PR DESCRIPTION
Fixes traceback when running tcms-run against current stage. Without the fix it dies with the following error:

```
 INFO  Fetching version '9.0' of 'Red Hat Enterprise Linux 9'
 DEBUG  Removing cache_dir /tmp/tmpz7l8p7u6
Traceback (most recent call last):
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 522, in __dump
    f = self.dispatch[type(value)]
        ~~~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: <class 'getset_descriptor'>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/tcms-run", line 1010, in <module>
    process_plan(nitrate.TestPlan(testplan))
  File "/usr/bin/tcms-run", line 984, in process_plan
    test_run, summary = create_update_run(
                        ^^^^^^^^^^^^^^^^^^
  File "/usr/bin/tcms-run", line 879, in create_update_run
    testrun = create_run(testplan, distro, summary, notes, errata)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/tcms-run", line 374, in create_run
    testrun = nitrate.TestRun(
              ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/nitrate/mutable.py", line 520, in __init__
    self._create(testplan=testplan, **kwargs)
  File "/usr/lib/python3.12/site-packages/nitrate/mutable.py", line 569, in _create
    hash["product_version"] = version.id
                              ^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/nitrate/base.py", line 65, in getter
    self._fetch()
  File "/usr/lib/python3.12/site-packages/nitrate/immutable.py", line 991, in _fetch
    inject = self._server.Product.filter_versions(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 1122, in __call__
    return self.__send(self.__name, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 1458, in __request
    request = dumps(params, methodname, encoding=self.__encoding,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 981, in dumps
    data = m.dumps(params)
           ^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 514, in dumps
    dump(v, write)
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 536, in __dump
    f(self, value, write)
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 607, in dump_struct
    dump(v, write)
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 536, in __dump
    f(self, value, write)
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 627, in dump_instance
    self.dump_struct(value.__dict__, write)
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 607, in dump_struct
    dump(v, write)
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 536, in __dump
    f(self, value, write)
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 627, in dump_instance
    self.dump_struct(value.__dict__, write)
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 607, in dump_struct
    dump(v, write)
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 536, in __dump
    f(self, value, write)
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 627, in dump_instance
    self.dump_struct(value.__dict__, write)
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 607, in dump_struct
    dump(v, write)
  File "/usr/lib64/python3.12/xmlrpc/client.py", line 526, in __dump
    raise TypeError("cannot marshal %s objects" % type(value))
TypeError: cannot marshal <class 'getset_descriptor'> objects
```
